### PR TITLE
Support xpath

### DIFF
--- a/example/tests/VisualRegression.test.js
+++ b/example/tests/VisualRegression.test.js
@@ -55,7 +55,7 @@ describe("Visual Regression", () => {
 
     it("should capture screenshot of specific page element", async () => {
         //Arrange, Act
-        const screenshot = await (await feedbackpage.TopBar.SignInButton.getDomElement()).screenshot();
+        const screenshot = await (await feedbackpage.TopBar.SignInButton.wait()).screenshot();
 
         //Assert
         expect(screenshot).toMatchImageSnapshot();

--- a/example/tests/VisualRegression.test.js
+++ b/example/tests/VisualRegression.test.js
@@ -77,7 +77,7 @@ describe("Visual Regression", () => {
 
     it("should cover unwanted element before making screenshot comparison", async () => {
         //Arrange
-        homepage.NavigationBar.cover();
+        await homepage.NavigationBar.cover();
 
         //Act
         const screenshot = await page.screenshot();

--- a/example/tests/elementActions.test.js
+++ b/example/tests/elementActions.test.js
@@ -14,6 +14,18 @@ describe("Element Actions", () => {
         expect(element.selector).toMatch("some.selector");
     });
 
+    it("should get child element by XPath selector", async () => {
+        //Arrange
+        await page.goto("http://the-internet.herokuapp.com/");
+
+        //Act
+        const element = new Element("//div[@id='content']");
+        const childElement = element.newChildElement("//h1");
+
+        //Assert
+        await expect(childElement.isVisible()).resolves.toBeTruthy();
+    });
+
     it("should wait for an element", async () => {
         //Arrange
         await page.goto("http://the-internet.herokuapp.com/dynamic_loading/2");
@@ -192,10 +204,10 @@ describe("Element Actions", () => {
         const headerText = new Element(".heading");
 
         //Act
-        const headerTextDomElement = await headerText.getDomElement();
+        const headerTextDomElement = await headerText.wait();
 
         //Assert
-        await expect(page.evaluate(domElement => domElement.textContent, headerTextDomElement)).resolves.toMatch("Welcome to the-internet");
+        await expect(headerTextDomElement.evaluate(domElement => domElement.textContent)).resolves.toMatch("Welcome to the-internet");
     });
 
     it("should get element's value", async () => {

--- a/example/tests/interceptor.test.js
+++ b/example/tests/interceptor.test.js
@@ -80,7 +80,7 @@ describe("Interceptor", () => {
         });
 
         //Act
-        await interceptor.abortRequestsDuringAction(addToCartButton.click());
+        await interceptor.abortRequestsDuringAction(() => { addToCartButton.click(); });
 
         //Assert
         await expect(successMessage.isVisible()).resolves.toBeFalsy();


### PR DESCRIPTION
This PR purpose is to make Element class to support XPath selectors same way it does css now
- waitForSelector waiters changes to waitFor, which support both css and xpath https://pptr.dev/#?product=Puppeteer&version=v3.0.1&show=api-pagewaitforselectororfunctionortimeout-options-args
- wait() methods refactored to return JSHandle
- Other methods refactored to reuse JSHandle returned by wait method, instead of using page API. This way we can avoid using any special XPath apis (like page.x$, and waitForXpath)
