### PR TITLE
Added jsconfig.json and example tests fixes to improve Intellisense support

### DIFF
--- a/example/tests/VisualRegression.test.js
+++ b/example/tests/VisualRegression.test.js
@@ -3,13 +3,8 @@ import HomePage from "../pages/HomePage";
 import FeedbackPage from "../pages/FeedbackPage";
 
 describe("Visual Regression", () => {
-    let homepage;
-    let feedbackpage;
-
-    beforeAll(async () => {
-        homepage = new HomePage();
-        feedbackpage = new FeedbackPage();
-    });
+    let homepage = new HomePage();
+    let feedbackpage = new FeedbackPage();
 
     beforeEach(async () => {
         await homepage.visit();

--- a/example/tests/helpers.test.js
+++ b/example/tests/helpers.test.js
@@ -3,11 +3,7 @@ import { Element, Helpers } from "test-juggler";
 const fs = require("fs");
 
 describe("Helpers", () => {
-    let helpers;
-
-    beforeAll(async () => {
-        helpers = new Helpers();
-    });
+    let helpers = new Helpers();
 
     beforeEach(async () => {
         console.log("Running test: " + jasmine["currentTest"].fullName);

--- a/example/tests/pageObjectModel.test.js
+++ b/example/tests/pageObjectModel.test.js
@@ -2,13 +2,8 @@ import HomePage from "../pages/HomePage";
 import FeedbackPage from "../pages/FeedbackPage";
 
 describe("Example", () => {
-    let homepage;
-    let feedbackpage;
-
-    beforeAll(async () => {
-        homepage = new HomePage();
-        feedbackpage = new FeedbackPage();
-    });
+    let homepage = new HomePage();
+    let feedbackpage = new FeedbackPage();
 
     beforeEach(async () => {
         await homepage.visit();

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es6",
+    "allowSyntheticDefaultImports": true
+  }
+}

--- a/post-install.js
+++ b/post-install.js
@@ -8,7 +8,7 @@
 
 var gentlyCopy = require("gently-copy");
 
-var filesToCopy = ["test-environment", "babel.config.js", "framework.config.js", "jest-puppeteer.config.js", "jest.config.js"];
+var filesToCopy = ["test-environment", "babel.config.js", "framework.config.js", "jest-puppeteer.config.js", "jest.config.js", "jsconfig.json"];
 
 if (process.env.DO_NOT_INSTALL_EXAMPLES !== "true") {
     filesToCopy.push("example");


### PR DESCRIPTION
1. Jsconfig.json somehow helps VSCode intellisense to catch puppeteer API (i.e. page.)
2. In example tests, intellisense works for page object classes (i.e. homepage.) when these are declared and initialized in the same line (i.e. let homepage = new HomePage();)
