### PR TITLE
Change focus() to _scrollIntoViewIfNeeded() in getCoordinates method.

### DIFF
--- a/framework/Element.js
+++ b/framework/Element.js
@@ -46,7 +46,7 @@ export default class Element {
 
     async getCoordinates(xOffset = null, yOffset = null) {
         const elementHandle = await this.wait();
-        await elementHandle.focus();
+        await elementHandle._scrollIntoViewIfNeeded();
         const rect = await elementHandle.boundingBox();
         const x = xOffset !== null ? xOffset : rect.width / 2;
         const y = yOffset !== null ? yOffset : rect.height / 2;


### PR DESCRIPTION
Changed focus() to _scrollIntoViewIfNeeded() in getCoordinates method.
Sample tests:
![image](https://user-images.githubusercontent.com/4601558/97145055-410acb80-176e-11eb-9e5d-dc2ac49b22ea.png)
