### PR TITLE
#85 Refactor clicks and hover methods

### DIFF
--- a/example/tests/elementActions.test.js
+++ b/example/tests/elementActions.test.js
@@ -235,8 +235,8 @@ describe("Element Actions", () => {
     it.each`
     action                                                  | selectedAttr  | pieClickedAttr    | description
     ${async () => { sliceToClick.hover(150); }}             | ${null}       | ${null}           | ${"hover"}
-    ${async () => { sliceToClick.click(150); }}             | ${"true"}     | ${"true"}         | ${"left-click"}
-    ${async () => { sliceToClick.rightClick(null, 100); }}  | ${"true"}     | ${null}           | ${"right-click"}
+    ${async () => { sliceToClick.click(null, 85); }}        | ${"true"}     | ${"true"}         | ${"left-click"}
+    ${async () => { sliceToClick.rightClick(100, 90); }}    | ${"true"}     | ${null}           | ${"right-click"}
     `("should $description element with offset", async ({ action, selectedAttr, pieClickedAttr }) => {
     //Arrange
     const toolTip = new Element(".apexcharts-tooltip.apexcharts-active");
@@ -293,7 +293,7 @@ describe("Element Actions", () => {
         await page.goto("https://stackoverflow.com/users/login");
 
         //Act
-        const coordinates = await rectangleCanvas.getCoordinates();
+        const coordinates = await rectangleCanvas.getElementClickCoordinates();
 
         //Assert
         expect(coordinates.x).toEqual(expectedXCoordinate);

--- a/example/tests/elementActions.test.js
+++ b/example/tests/elementActions.test.js
@@ -293,7 +293,7 @@ describe("Element Actions", () => {
         await page.goto("https://stackoverflow.com/users/login");
 
         //Act
-        const coordinates = await rectangleCanvas.getElementClickCoordinates();
+        const coordinates = await rectangleCanvas.getCoordinates();
 
         //Assert
         expect(coordinates.x).toEqual(expectedXCoordinate);

--- a/example/tests/helpers.test.js
+++ b/example/tests/helpers.test.js
@@ -47,18 +47,6 @@ describe("Helpers", () => {
         await expect(elementToLoad.exists()).resolves.toBeTruthy();
     });
 
-    it("should wait for navigation to be finished", async () => {
-        //Arrange
-        const progressLoader = new Element("html.nprogress-busy");
-        const loadTimeout = 30000;
-
-        //Act
-        await Helpers.goToUrlAndLoad("https://www.jqueryscript.net/demo/jQuery-Html5-Based-Preloader-Plugin-html5loader/", loadTimeout);
-
-        //Assert
-        await expect(progressLoader.exists()).resolves.toBeFalsy();
-    });
-
     it("should enter iFrame and get text", async () => {
         //Arrange
         const iFrameSelector = "#mce_0_ifr";

--- a/example/tests/interceptor.test.js
+++ b/example/tests/interceptor.test.js
@@ -1,4 +1,4 @@
-import { Element, Helpers, Interceptor } from "test-juggler";
+import { Element, Interceptor } from "test-juggler";
 
 const DemoQaSite = "https://demoqa.com/books";
 const DemoOpenCartSite = "https://demo.opencart.com/";
@@ -95,7 +95,7 @@ describe("Interceptor", () => {
 
     it("should count all requests", async () => {
         //Act
-        var totalRequests = await Interceptor.getAllRequestsData(Helpers.goToUrlAndLoad(DemoOpenCartSite));
+        var totalRequests = await Interceptor.getAllRequestsData(page.goto(DemoOpenCartSite));
 
         //Assert
         expect(totalRequests.length > 0).toBeTruthy();
@@ -105,7 +105,7 @@ describe("Interceptor", () => {
     it("should detect specific response after action", async () => {
         //Arrange
         const responseUrlFragment = "cart/info";
-        await Helpers.goToUrlAndLoad(DemoOpenCartSite);
+        await page.goto(DemoOpenCartSite);
 
         //Act
         var responseAfterAction = await Interceptor.waitForResponseAfterAction(addToCartButton.click(), responseUrlFragment);
@@ -119,7 +119,7 @@ describe("Interceptor", () => {
 
     it("should detect any request after action", async () => {
         //Arrange
-        await Helpers.goToUrlAndLoad(DemoOpenCartSite);
+        await page.goto(DemoOpenCartSite);
 
         //Act
         var requestAfterAction = await Interceptor.waitForRequestAfterAction(addToCartButton.click());

--- a/framework/Element.js
+++ b/framework/Element.js
@@ -43,41 +43,50 @@ export default class Element {
         }
     }
 
-    async getCoordinates(xOffset = null, yOffset = null) {
+    async getElementClickCoordinates(xOffset = null, yOffset = null) {
         const elementHandle = await this.wait();
-        await elementHandle.scrollIntoViewIfNeeded();
         const rect = await elementHandle.boundingBox();
-        const x = xOffset !== null ? xOffset : rect.width / 2;
-        const y = yOffset !== null ? yOffset : rect.height / 2;
-        const xCoordinate = rect.x + x;
-        const yCoordinate = rect.y + y;
-        console.log(`Action on page at position x: ${xCoordinate}, y: ${yCoordinate}`);
-        console.log(`Action on element rectangle at position x: ${x}, y: ${y}`);
-        return { x: xCoordinate, y: yCoordinate };
+        const xCoordinate = xOffset !== null ? xOffset : rect.width / 2;
+        const yCoordinate = yOffset !== null ? yOffset : rect.height / 2;
+        console.log(`Element width: ${rect.width}, height: ${rect.height}`);
+        console.log(`Action on element rectangle at position x: ${xCoordinate}, y: ${yCoordinate}`);
+        return  { x: xCoordinate, y: yCoordinate };
     }
 
     async click(xOffset = null, yOffset = null) {
         console.log(`Clicking ${this.selector} ...`);
-        const coordinates = await this.getCoordinates(xOffset, yOffset);
-        await page.mouse.click(coordinates.x, coordinates.y);
+        if (xOffset != null || yOffset != null) {
+            const coordinates = await this.getElementClickCoordinates(xOffset, yOffset);
+            await page.click(this.selector, { position: { x: coordinates.x, y: coordinates.y } });
+        }
+        else await page.click(this.selector);
     }
 
     async doubleClick(xOffset = null, yOffset = null) {
         console.log(`Double clicking ${this.selector} ...`);
-        const coordinates = await this.getCoordinates(xOffset, yOffset);
-        await page.mouse.click(coordinates.x, coordinates.y, { clickCount: 2 });
+        if (xOffset != null || yOffset != null) {
+            const coordinates = await this.getElementClickCoordinates(xOffset, yOffset);
+            await page.dblclick(this.selector, { position: { x: coordinates.x, y: coordinates.y } });
+        }
+        else await page.dblclick(this.selector);
     }
 
     async rightClick(xOffset = null, yOffset = null) {
         console.log(`Right clicking ${this.selector} ...`);
-        const coordinates = await this.getCoordinates(xOffset, yOffset);
-        await page.mouse.click(coordinates.x, coordinates.y, { button: "right" });
+        if (xOffset != null || yOffset != null) {
+            const coordinates = await this.getElementClickCoordinates(xOffset, yOffset);
+            await page.click(this.selector, { position: { x: coordinates.x, y: coordinates.y }, button: "right" } );
+        }
+        else await page.click(this.selector, { button: "right" });
     }
 
     async hover(xOffset = null, yOffset = null) {
         console.log(`Hovering mouse on to ${this.selector} ...`);
-        const coordinates = await this.getCoordinates(xOffset, yOffset);
-        await page.mouse.move(coordinates.x, coordinates.y);
+        if (xOffset != null || yOffset != null) {
+            const coordinates = await this.getElementClickCoordinates(xOffset, yOffset);
+            await page.hover(this.selector, { position: { x: coordinates.x, y: coordinates.y } });
+        }
+        else await page.hover(this.selector);
     }
 
     async exists() {

--- a/framework/Element.js
+++ b/framework/Element.js
@@ -43,7 +43,7 @@ export default class Element {
         }
     }
 
-    async getElementClickCoordinates(xOffset = null, yOffset = null) {
+    async getCoordinates(xOffset = null, yOffset = null) {
         const elementHandle = await this.wait();
         const rect = await elementHandle.boundingBox();
         const xCoordinate = xOffset !== null ? xOffset : rect.width / 2;
@@ -56,7 +56,7 @@ export default class Element {
     async click(xOffset = null, yOffset = null) {
         console.log(`Clicking ${this.selector} ...`);
         if (xOffset != null || yOffset != null) {
-            const coordinates = await this.getElementClickCoordinates(xOffset, yOffset);
+            const coordinates = await this.getCoordinates(xOffset, yOffset);
             await page.click(this.selector, { position: { x: coordinates.x, y: coordinates.y } });
         }
         else await page.click(this.selector);
@@ -65,7 +65,7 @@ export default class Element {
     async doubleClick(xOffset = null, yOffset = null) {
         console.log(`Double clicking ${this.selector} ...`);
         if (xOffset != null || yOffset != null) {
-            const coordinates = await this.getElementClickCoordinates(xOffset, yOffset);
+            const coordinates = await this.getCoordinates(xOffset, yOffset);
             await page.dblclick(this.selector, { position: { x: coordinates.x, y: coordinates.y } });
         }
         else await page.dblclick(this.selector);
@@ -74,7 +74,7 @@ export default class Element {
     async rightClick(xOffset = null, yOffset = null) {
         console.log(`Right clicking ${this.selector} ...`);
         if (xOffset != null || yOffset != null) {
-            const coordinates = await this.getElementClickCoordinates(xOffset, yOffset);
+            const coordinates = await this.getCoordinates(xOffset, yOffset);
             await page.click(this.selector, { position: { x: coordinates.x, y: coordinates.y }, button: "right" } );
         }
         else await page.click(this.selector, { button: "right" });
@@ -83,7 +83,7 @@ export default class Element {
     async hover(xOffset = null, yOffset = null) {
         console.log(`Hovering mouse on to ${this.selector} ...`);
         if (xOffset != null || yOffset != null) {
-            const coordinates = await this.getElementClickCoordinates(xOffset, yOffset);
+            const coordinates = await this.getCoordinates(xOffset, yOffset);
             await page.hover(this.selector, { position: { x: coordinates.x, y: coordinates.y } });
         }
         else await page.hover(this.selector);

--- a/framework/helpers.js
+++ b/framework/helpers.js
@@ -1,7 +1,5 @@
 const fs = require("fs");
 const retry = require("async-retry");
-const config = require(process.cwd() + "/framework.config");
-const defaultTimeout = config.defaultTimeout;
 const defaultCharacters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 
 class Helpers {
@@ -23,12 +21,6 @@ class Helpers {
             minTimeout: minTimeout,
             maxTimeout: Infinity,
             randomize: false,
-        });
-    }
-
-    async goToUrlAndLoad(url, timeout = defaultTimeout) {
-        await page.goto(url, {
-            waitUntil: "networkidle", timeout: timeout,
         });
     }
 


### PR DESCRIPTION
- Refactored getCoordinates method;
- Refactored click method;
- Refactored doubleclick mehtod;
- Refactored right-click mehtod;
- Refactored hover mehtod;
- Removed goToUrlAndLoad method from helpers class (page.goto is enough which can be used with different options)
- Removed goToUrlAndLoad example test.
![image](https://user-images.githubusercontent.com/4601558/108234689-b8190500-714d-11eb-982a-aff236374136.png)
